### PR TITLE
Species fix

### DIFF
--- a/api/brapi.api.inc
+++ b/api/brapi.api.inc
@@ -434,7 +434,7 @@ function brapi_filter_autocomplete($data_type, $field, $string) {
       );
       $cvterm_ids = array();
       foreach ($records as $record) {
-        $cvterm_ids[] = $record->$field_fetcher['column'];
+        $cvterm_ids[] = $record->{$field_fetcher['column']};
       }
       $cvterm_records = chado_select_record(
          'cvterm',
@@ -1302,13 +1302,13 @@ function brapi_get_field(
     case 'array':
       // Get from database using mapping config.
       if (isset($field_fetcher['object_key'])) {
-        $identifier = $object->$field_fetcher['object_key'];
+        $identifier = $object->{$field_fetcher['object_key']};
         if (is_object($identifier)) {
-          $identifier = $identifier->$field_fetcher['foreign_key'];
+          $identifier = $identifier->{$field_fetcher['foreign_key']};
         }
       }
       else {
-        $identifier = $object->$data_mapping[$data_type]['identifier'];
+        $identifier = $object->{$data_mapping[$data_type]['identifier']};
       }
 
       $selector = brapi_get_field_selector($data_type, $field_name, $identifier);
@@ -1341,7 +1341,7 @@ function brapi_get_field(
           $records = array($records);
         }
         foreach ($records as $record) {
-          $current_value = $record->$field_fetcher['column'];
+          $current_value = $record->{$field_fetcher['column']};
           // Check type and return the appropriate conversion.
           try {
             $current_value = brapi_decode_value($current_value, $field_fetcher['field_type']);
@@ -1500,7 +1500,7 @@ function brapi_set_field(
     case "string":
       // Set through object.
       $object->$field_fetcher = $field_value;
-      // +FIXME: $object->save(); ?
+      //@todo: $object->save(); ?
       break;
 
     case "array":
@@ -1520,7 +1520,7 @@ function brapi_set_field(
           // Remove previous values.
           // We capture output buffer for Tripal error messages.
           ob_start();
-          $selector = brapi_get_field_selector($data_type, $field_name, $object->$data_mapping[$data_type]['identifier']);
+          $selector = brapi_get_field_selector($data_type, $field_name, $object->{$data_mapping[$data_type]['identifier']});
           $deleted_record = chado_delete_record(
             $field_fetcher['table'],
             $selector
@@ -1543,7 +1543,7 @@ function brapi_set_field(
           // @todo Check value type. Do some conversion if needed and possible.
           // We capture output buffer for Tripal error messages.
           ob_start();
-          $selector = brapi_get_field_selector($data_type, $field_name, $object->$data_mapping[$data_type]['identifier']);
+          $selector = brapi_get_field_selector($data_type, $field_name, $object->{$data_mapping[$data_type]['identifier']});
           try {
             $single_value = brapi_encode_value($single_value, $data_mapping[$data_type]['fields'][$field_name]['field_type']);
           }
@@ -1596,10 +1596,10 @@ function brapi_set_field(
           $foreign_key = $data_mapping[$data_type]['identifier'];
         }
         if (isset($field_fetcher['object_key'])) {
-          $identifier = $object->$field_fetcher['object_key'];
+          $identifier = $object->{$field_fetcher['object_key']};
         }
         else {
-          $identifier = $object->$data_mapping[$data_type]['identifier'];
+          $identifier = $object->{$data_mapping[$data_type]['identifier']};
         }
         // Check value type and do some conversion if needed.
         try {

--- a/api/brapi.api.inc
+++ b/api/brapi.api.inc
@@ -3144,7 +3144,7 @@ function brapi_query_form($form, &$form_state, $call_name, $call_info) {
 
   );
 
-  if (user_access('administer')) {
+  if (user_access(BRAPI_ADMIN_PERMISSION)) {
     $call_fieldset['global']['debug'] = array(
       '#type' => 'checkbox',
       '#title' => t('Enable debug mode'),

--- a/api/brapi.api.inc
+++ b/api/brapi.api.inc
@@ -354,8 +354,18 @@ function brapi_terms_autocomplete($string) {
 
   if ($string) {
     // Get last term entered after the last coma for completion.
-    $items = array_map('trim', explode(',', $string));
+    $items = array_filter(array_map(
+      function ($a) {
+        return trim(str_replace("\\,", ',', $a));
+      },
+      preg_split('/(?<!\\\\),/', $string)
+    ));
     $last_item = array_pop($items);
+    if (empty($last_item)) {
+      drupal_json_output($matches);
+      return;
+    }
+    
     $prefix = implode(', ', $items);
 
     $sql_query = "

--- a/api/brapi.calls.inc
+++ b/api/brapi.calls.inc
@@ -812,7 +812,7 @@ function brapi_v1_authentication_json() {
  * - call (string)
  *     The name of a call.
  */
-function brapi_v1_call_10_json($selected_call_name) {
+function brapi_v1_call_10_json($selected_call_name = NULL) {
 
   // Init status and debug data.
   $call_data = array();
@@ -908,7 +908,7 @@ function brapi_v1_call_10_json($selected_call_name) {
  * - call (string)
  *     The name of a call.
  */
-function brapi_v1_call_12_json($selected_call_name) {
+function brapi_v1_call_12_json($selected_call_name = NULL) {
 
   // Init status and debug data.
   $call_data = array();
@@ -1074,7 +1074,7 @@ function brapi_v1_germplasm_search_json() {
  *
  * @ingroup brapi
  */
-function brapi_v1_germplasm_json($germplasm_id) {
+function brapi_v1_germplasm_json($germplasm_id = NULL) {
 
   $actions = array(
     'create' => 'brapi_v1_create_germplasm_json',
@@ -1631,7 +1631,7 @@ function brapi_v1_delete_germplasm_json($stock) {
  *
  * @ingroup brapi
  */
-function brapi_v1_germplasm_pedigree_10_json($germplasm_id) {
+function brapi_v1_germplasm_pedigree_10_json($germplasm_id = NULL) {
 
   $actions = array(
     'read'   => 'brapi_v1_read_germplasm_pedigree_10_json',
@@ -1649,7 +1649,7 @@ function brapi_v1_germplasm_pedigree_10_json($germplasm_id) {
  *
  * @see http://wheat.pw.usda.gov/ggpages/gopher/administration/Template%20for%20Germplasm%20records.html
  */
-function brapi_v1_germplasm_pedigree_11_json($germplasm_id) {
+function brapi_v1_germplasm_pedigree_11_json($germplasm_id = NULL) {
 
   $actions = array(
     'read'   => 'brapi_v1_read_germplasm_pedigree_11_json',
@@ -1992,7 +1992,7 @@ function brapi_v1_categories_json() {
  *
  * @ingroup brapi
  */
-function brapi_v1_germplasm_attributes_json($germplasm_id) {
+function brapi_v1_germplasm_attributes_json($germplasm_id = NULL) {
 
   $actions = array(
     'read'   => 'brapi_v1_read_germplasm_attributes_json',
@@ -2172,7 +2172,7 @@ function brapi_v1_crops_json() {
  *
  * @ingroup brapi
  */
-function brapi_v1_marker_json($marker_id) {
+function brapi_v1_marker_json($marker_id = NULL) {
   $actions = array(
     'read'   => 'brapi_v1_read_marker_json',
     'list'   => 'brapi_v1_marker_search_json',
@@ -2295,7 +2295,7 @@ function brapi_v1_marker_search_json() {
  *
  * @ingroup brapi
  */
-function brapi_v1_location_json($location_id) {
+function brapi_v1_location_json($location_id = NULL) {
   $actions = array(
     'read' => 'brapi_v1_read_location_json',
     'list' => 'brapi_v1_location_search_json',
@@ -2415,7 +2415,7 @@ function brapi_v1_location_search_json() {
  *
  * @ingroup brapi
  */
-function brapi_v1_program_json($program_id) {
+function brapi_v1_program_json($program_id = NULL) {
   $actions = array(
     'read' => 'brapi_v1_read_program_json',
     'list' => 'brapi_v1_program_search_json',
@@ -2542,7 +2542,7 @@ function brapi_v1_sample_search_json() {
  *
  * @ingroup brapi
  */
-function brapi_v1_sample_json($sample_id) {
+function brapi_v1_sample_json($sample_id = NULL) {
 
   $actions = array(
     'create' => 'brapi_v1_create_sample_json',
@@ -2956,7 +2956,7 @@ function brapi_v1_delete_sample_json($stock) {
  *
  * @ingroup brapi
  */
-function brapi_v1_variable_json($variable_id) {
+function brapi_v1_variable_json($variable_id = NULL) {
   $actions = array(
     'read' => 'brapi_v1_read_variable_json',
     'list' => 'brapi_v1_variable_search_json',

--- a/api/brapi.const.inc
+++ b/api/brapi.const.inc
@@ -222,7 +222,7 @@ function brapi_get_mcpd_mapping() {
  *       which can be used for filtering;
  *   - 'features' (array): an array of feature name => value/description
  *     supported by the call;
- *   - 'aggregatable' (bool): if true, the call can be aggregated with other
+ *   - 'aggregable' (bool): if true, the call can be aggregated with other
  *     BrAPI sites providing the same call.
  *
  * @ingroup brapi_const
@@ -243,7 +243,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_about_json',
         ),
-        'aggregatable' => FALSE,
+        'aggregable' => FALSE,
       ),
       'allelematrices'     => array(
         'title'          => 'Allele Matrices',
@@ -259,7 +259,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_external_call_json',
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'allelematrices-search'      => array(
         'title'          => 'MarkerProfile Allele Matrix',
@@ -275,7 +275,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_external_call_json',
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'allelematrix'     => array(
         'title'          => 'Allele Matrices',
@@ -290,7 +290,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.2' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'allelematrix-search'      => array(
         'title'          => 'MarkerProfile Allele Matrix',
@@ -305,7 +305,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.2' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'attributes' => array(
         'title'          => 'Germplasm Attribute List',
@@ -320,7 +320,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_attributes_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'attributes/categories' => array(
         'title'          => 'Germplasm Attribute Category List',
@@ -335,7 +335,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_categories_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'calls'      => array(
         'title'          => 'Call Search',
@@ -359,7 +359,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => FALSE,
+        'aggregable' => FALSE,
       ),
       'crops' => array(
         'title'          => 'Crops',
@@ -375,7 +375,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_crops_json',
           '1.1' => 'brapi_v1_crops_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'germplasm' => array(
         'title'          => 'Germplasm',
@@ -391,7 +391,7 @@ function brapi_get_calls() {
           '1.1' => 'brapi_v1_germplasm_json',
         ),
         'features'       => array('MCPD' => 'yes', 'MCPD-version' => 'V.' . BRAPI_MCPD_VERSION),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'germplasm/{germplasmDbId}' => array(
         'title'          => 'Germplasm Details',
@@ -418,7 +418,7 @@ function brapi_get_calls() {
           ),
         ),
         'features'       => array('MCPD' => 'yes', 'MCPD-version' => 'V.' . BRAPI_MCPD_VERSION),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'germplasm/{germplasmDbId}/attributes' => array(
         'title'          => 'Germplasm Attributes',
@@ -440,7 +440,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'germplasm/{germplasmDbId}/markerprofiles' => array(
         'title'          => 'Germplasm Markerprofiles',
@@ -462,7 +462,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'germplasm/{germplasmDbId}/pedigree' => array(
         'title'          => 'Germplasm Pedigree',
@@ -485,7 +485,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'germplasm-search' => array(
         'title'          => 'Germplasm Search',
@@ -573,7 +573,7 @@ function brapi_get_calls() {
           ),
         ),
         'features'       => array('MCPD' => 'yes', 'MCPD-version' => 'V.' . BRAPI_MCPD_VERSION),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'locations' => array(
         'title'          => 'Locations',
@@ -588,7 +588,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_location_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'locations/{locationDbId}' => array(
         'title'          => 'Locations Details',
@@ -610,7 +610,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_location_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'maps'      => array(
         'title'          => 'Genome Map',
@@ -625,7 +625,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'maps/{mapDbId}' => array(
         'title'          => 'Genome Map Details',
@@ -640,7 +640,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'maps/{mapDbId}/positions' => array(
         'title'          => 'Genome map data',
@@ -655,7 +655,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'maps/{mapDbId}/positions/{linkageGroupName}' => array(
         'title'          => 'Genome Map Data by range on linkageGroup',
@@ -670,7 +670,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'markerprofiles'      => array(
         'title'          => 'Markerprofile Search',
@@ -685,7 +685,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'markerprofiles/{markerprofileDbId}' => array(
         'title'          => 'Marker profiles',
@@ -700,7 +700,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'markers' => array(
         'title'          => 'Marker List',
@@ -715,7 +715,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_marker_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'markers/{markerDbId}' => array(
         'title'          => 'Marker Details',
@@ -737,7 +737,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'markers-search'      => array(
         'title'          => 'Markers Search',
@@ -752,7 +752,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_marker_search_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'observationlevels' => array(
         'title'          => 'Observation Level List',
@@ -767,7 +767,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'ontologies' => array(
         'title'          => 'Variable ontology list',
@@ -782,7 +782,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'phenotypes-search'      => array(
         'title'          => 'Phenotype Search',
@@ -797,7 +797,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'phenotypes'      => array(
         'title'          => 'Phenotype List',
@@ -812,7 +812,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'phenotypes/{phenotypeDbId}' => array(
         'title'          => 'Phenotype Details',
@@ -835,7 +835,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'programs'      => array(
         'title'          => 'Program List',
@@ -850,7 +850,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_program_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'programs/{programDbId}' => array(
         'title'          => 'Program Details',
@@ -872,7 +872,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'programs-search'      => array(
         'title'          => 'Program Search',
@@ -887,7 +887,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_program_search_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'samples' => array(
         'title'          => 'Sample List',
@@ -902,7 +902,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_sample_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'samples/{sampleDbId}' => array(
         'title'          => 'Sample Details',
@@ -927,7 +927,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'samples-search' => array(
         'title'          => 'Sample Search',
@@ -942,7 +942,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_sample_search_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'seasons'      => array(
         'title'          => 'Season List',
@@ -957,7 +957,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies'      => array(
         'title'          => 'Study List',
@@ -972,7 +972,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}'      => array(
         'title'          => 'Study Details',
@@ -995,7 +995,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}/germplasm'      => array(
         'title'          => 'Study Germplasm Details',
@@ -1018,7 +1018,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}/layout'      => array(
         'title'          => 'Plot Layout Details',
@@ -1041,7 +1041,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}/observations'      => array(
         'title'          => 'Observations Details',
@@ -1064,7 +1064,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}/observationunits'      => array(
         'title'          => 'Observation Units Details',
@@ -1087,7 +1087,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}/observationvariables'      => array(
         'title'          => 'Study Observation Variables',
@@ -1110,7 +1110,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}/table'      => array(
         'title'          => 'Study Observation Units as a Table',
@@ -1133,7 +1133,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies-search'      => array(
         'title'          => 'Study search',
@@ -1148,7 +1148,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studytypes'      => array(
         'title'          => 'Study Type List',
@@ -1163,7 +1163,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'token'      => array(
         'title'          => 'Authentication',
@@ -1180,7 +1180,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_authentication_json',
           '1.1' => 'brapi_v1_authentication_json',
         ),
-        'aggregatable' => FALSE,
+        'aggregable' => FALSE,
       ),
       'traits'      => array(
         'title'          => 'Trait List',
@@ -1195,7 +1195,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'traits/{traitDbId}' => array(
         'title'          => 'Trait Details',
@@ -1218,7 +1218,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'trials'      => array(
         'title'          => 'Trial List',
@@ -1233,7 +1233,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'trials/{trialDbId}' => array(
         'title'          => 'Trial Details',
@@ -1256,7 +1256,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'variables'      => array(
         'title'          => 'Variable List',
@@ -1271,7 +1271,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_variable_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'variables/{observationVariableDbId}' => array(
         'title'          => 'Variable Details',
@@ -1294,7 +1294,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'variables/datatypes' => array(
         'title'          => 'Variable Data Types',
@@ -1310,7 +1310,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_variable_datatypes_json',
           '1.1' => 'brapi_v1_variable_datatypes_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'variables-search' => array(
         'title'          => 'Variable Search',
@@ -1325,7 +1325,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_variable_search_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'vendors/plates/{vendorPlateDbId}' => array(
         'title'          => 'Plate Details',
@@ -1348,7 +1348,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'vendors/plates-search' => array(
         'title'          => 'Plate Search',
@@ -1363,7 +1363,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'vendors/specifications' => array(
         'title'          => 'Vendor Specifications',
@@ -1378,7 +1378,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
     );
 
@@ -1821,16 +1821,8 @@ function brapi_get_data_mapping() {
                 break;
 
               case 'read':
-                $pui = NULL;
-                // Tripal 2.
-                if (function_exists('chado_get_nid_from_id')) {
-                  $pui = chado_get_nid_from_id('stock', $stock->stock_id);
-                  $germplasm_pui = $base_url . '/' . drupal_get_path_alias('node/' . $pui);
-                }
-                // Tripal 3.
-                if (function_exists('chado_get_record_entity_by_table')) {
-                  $pui = chado_get_record_entity_by_table('stock', $stock->stock_id);
-                  $germplasm_pui = $base_url . '/' . drupal_get_path_alias('bio_data/' . $pui);
+                if ($nid = chado_get_nid_from_id('stock', $stock->stock_id)) {
+                  $germplasm_pui = $base_url . '/' . drupal_get_path_alias('node/' . $nid);
                 }
                 break;
 

--- a/api/brapi.const.inc
+++ b/api/brapi.const.inc
@@ -222,7 +222,7 @@ function brapi_get_mcpd_mapping() {
  *       which can be used for filtering;
  *   - 'features' (array): an array of feature name => value/description
  *     supported by the call;
- *   - 'aggregatable' (bool): if true, the call can be aggregated with other
+ *   - 'aggregable' (bool): if true, the call can be aggregated with other
  *     BrAPI sites providing the same call.
  *
  * @ingroup brapi_const
@@ -243,7 +243,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_about_json',
         ),
-        'aggregatable' => FALSE,
+        'aggregable' => FALSE,
       ),
       'allelematrices'     => array(
         'title'          => 'Allele Matrices',
@@ -259,7 +259,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_external_call_json',
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'allelematrices-search'      => array(
         'title'          => 'MarkerProfile Allele Matrix',
@@ -275,7 +275,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_external_call_json',
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'allelematrix'     => array(
         'title'          => 'Allele Matrices',
@@ -290,7 +290,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.2' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'allelematrix-search'      => array(
         'title'          => 'MarkerProfile Allele Matrix',
@@ -305,7 +305,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.2' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'attributes' => array(
         'title'          => 'Germplasm Attribute List',
@@ -320,7 +320,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_attributes_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'attributes/categories' => array(
         'title'          => 'Germplasm Attribute Category List',
@@ -335,7 +335,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_categories_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'calls'      => array(
         'title'          => 'Call Search',
@@ -359,7 +359,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => FALSE,
+        'aggregable' => FALSE,
       ),
       'crops' => array(
         'title'          => 'Crops',
@@ -375,7 +375,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_crops_json',
           '1.1' => 'brapi_v1_crops_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'germplasm' => array(
         'title'          => 'Germplasm',
@@ -391,7 +391,7 @@ function brapi_get_calls() {
           '1.1' => 'brapi_v1_germplasm_json',
         ),
         'features'       => array('MCPD' => 'yes', 'MCPD-version' => 'V.' . BRAPI_MCPD_VERSION),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'germplasm/{germplasmDbId}' => array(
         'title'          => 'Germplasm Details',
@@ -418,7 +418,7 @@ function brapi_get_calls() {
           ),
         ),
         'features'       => array('MCPD' => 'yes', 'MCPD-version' => 'V.' . BRAPI_MCPD_VERSION),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'germplasm/{germplasmDbId}/attributes' => array(
         'title'          => 'Germplasm Attributes',
@@ -440,7 +440,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'germplasm/{germplasmDbId}/markerprofiles' => array(
         'title'          => 'Germplasm Markerprofiles',
@@ -462,7 +462,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'germplasm/{germplasmDbId}/pedigree' => array(
         'title'          => 'Germplasm Pedigree',
@@ -485,7 +485,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'germplasm-search' => array(
         'title'          => 'Germplasm Search',
@@ -573,7 +573,7 @@ function brapi_get_calls() {
           ),
         ),
         'features'       => array('MCPD' => 'yes', 'MCPD-version' => 'V.' . BRAPI_MCPD_VERSION),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'locations' => array(
         'title'          => 'Locations',
@@ -588,7 +588,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_location_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'locations/{locationDbId}' => array(
         'title'          => 'Locations Details',
@@ -610,7 +610,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_location_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'maps'      => array(
         'title'          => 'Genome Map',
@@ -625,7 +625,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'maps/{mapDbId}' => array(
         'title'          => 'Genome Map Details',
@@ -640,7 +640,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'maps/{mapDbId}/positions' => array(
         'title'          => 'Genome map data',
@@ -655,7 +655,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'maps/{mapDbId}/positions/{linkageGroupName}' => array(
         'title'          => 'Genome Map Data by range on linkageGroup',
@@ -670,7 +670,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'markerprofiles'      => array(
         'title'          => 'Markerprofile Search',
@@ -685,7 +685,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'markerprofiles/{markerprofileDbId}' => array(
         'title'          => 'Marker profiles',
@@ -700,7 +700,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'markers' => array(
         'title'          => 'Marker List',
@@ -715,7 +715,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_marker_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'markers/{markerDbId}' => array(
         'title'          => 'Marker Details',
@@ -737,7 +737,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'markers-search'      => array(
         'title'          => 'Markers Search',
@@ -752,7 +752,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_marker_search_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'observationlevels' => array(
         'title'          => 'Observation Level List',
@@ -767,7 +767,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'ontologies' => array(
         'title'          => 'Variable ontology list',
@@ -782,7 +782,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'phenotypes-search'      => array(
         'title'          => 'Phenotype Search',
@@ -797,7 +797,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'phenotypes'      => array(
         'title'          => 'Phenotype List',
@@ -812,7 +812,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'phenotypes/{phenotypeDbId}' => array(
         'title'          => 'Phenotype Details',
@@ -835,7 +835,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'programs'      => array(
         'title'          => 'Program List',
@@ -850,7 +850,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_program_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'programs/{programDbId}' => array(
         'title'          => 'Program Details',
@@ -872,7 +872,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'programs-search'      => array(
         'title'          => 'Program Search',
@@ -887,7 +887,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_program_search_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'samples' => array(
         'title'          => 'Sample List',
@@ -902,7 +902,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_sample_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'samples/{sampleDbId}' => array(
         'title'          => 'Sample Details',
@@ -927,7 +927,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'samples-search' => array(
         'title'          => 'Sample Search',
@@ -942,7 +942,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_sample_search_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'seasons'      => array(
         'title'          => 'Season List',
@@ -957,7 +957,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies'      => array(
         'title'          => 'Study List',
@@ -972,7 +972,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}'      => array(
         'title'          => 'Study Details',
@@ -995,7 +995,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}/germplasm'      => array(
         'title'          => 'Study Germplasm Details',
@@ -1018,7 +1018,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}/layout'      => array(
         'title'          => 'Plot Layout Details',
@@ -1041,7 +1041,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}/observations'      => array(
         'title'          => 'Observations Details',
@@ -1064,7 +1064,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}/observationunits'      => array(
         'title'          => 'Observation Units Details',
@@ -1087,7 +1087,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}/observationvariables'      => array(
         'title'          => 'Study Observation Variables',
@@ -1110,7 +1110,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies/{studyDbId}/table'      => array(
         'title'          => 'Study Observation Units as a Table',
@@ -1133,7 +1133,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studies-search'      => array(
         'title'          => 'Study search',
@@ -1148,7 +1148,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'studytypes'      => array(
         'title'          => 'Study Type List',
@@ -1163,7 +1163,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'token'      => array(
         'title'          => 'Authentication',
@@ -1180,7 +1180,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_authentication_json',
           '1.1' => 'brapi_v1_authentication_json',
         ),
-        'aggregatable' => FALSE,
+        'aggregable' => FALSE,
       ),
       'traits'      => array(
         'title'          => 'Trait List',
@@ -1195,7 +1195,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'traits/{traitDbId}' => array(
         'title'          => 'Trait Details',
@@ -1218,7 +1218,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'trials'      => array(
         'title'          => 'Trial List',
@@ -1233,7 +1233,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'trials/{trialDbId}' => array(
         'title'          => 'Trial Details',
@@ -1256,7 +1256,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'variables'      => array(
         'title'          => 'Variable List',
@@ -1271,7 +1271,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_variable_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'variables/{observationVariableDbId}' => array(
         'title'          => 'Variable Details',
@@ -1294,7 +1294,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'variables/datatypes' => array(
         'title'          => 'Variable Data Types',
@@ -1310,7 +1310,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_variable_datatypes_json',
           '1.1' => 'brapi_v1_variable_datatypes_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'variables-search' => array(
         'title'          => 'Variable Search',
@@ -1325,7 +1325,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_variable_search_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'vendors/plates/{vendorPlateDbId}' => array(
         'title'          => 'Plate Details',
@@ -1348,7 +1348,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'vendors/plates-search' => array(
         'title'          => 'Plate Search',
@@ -1363,7 +1363,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
       'vendors/specifications' => array(
         'title'          => 'Vendor Specifications',
@@ -1378,7 +1378,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregatable' => TRUE,
+        'aggregable' => TRUE,
       ),
     );
 

--- a/api/brapi.const.inc
+++ b/api/brapi.const.inc
@@ -222,7 +222,7 @@ function brapi_get_mcpd_mapping() {
  *       which can be used for filtering;
  *   - 'features' (array): an array of feature name => value/description
  *     supported by the call;
- *   - 'aggregable' (bool): if true, the call can be aggregated with other
+ *   - 'aggregatable' (bool): if true, the call can be aggregated with other
  *     BrAPI sites providing the same call.
  *
  * @ingroup brapi_const
@@ -243,7 +243,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_about_json',
         ),
-        'aggregable' => FALSE,
+        'aggregatable' => FALSE,
       ),
       'allelematrices'     => array(
         'title'          => 'Allele Matrices',
@@ -259,7 +259,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_external_call_json',
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'allelematrices-search'      => array(
         'title'          => 'MarkerProfile Allele Matrix',
@@ -275,7 +275,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_external_call_json',
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'allelematrix'     => array(
         'title'          => 'Allele Matrices',
@@ -290,7 +290,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.2' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'allelematrix-search'      => array(
         'title'          => 'MarkerProfile Allele Matrix',
@@ -305,7 +305,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.2' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'attributes' => array(
         'title'          => 'Germplasm Attribute List',
@@ -320,7 +320,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_attributes_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'attributes/categories' => array(
         'title'          => 'Germplasm Attribute Category List',
@@ -335,7 +335,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_categories_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'calls'      => array(
         'title'          => 'Call Search',
@@ -359,7 +359,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregable' => FALSE,
+        'aggregatable' => FALSE,
       ),
       'crops' => array(
         'title'          => 'Crops',
@@ -375,7 +375,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_crops_json',
           '1.1' => 'brapi_v1_crops_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'germplasm' => array(
         'title'          => 'Germplasm',
@@ -391,7 +391,7 @@ function brapi_get_calls() {
           '1.1' => 'brapi_v1_germplasm_json',
         ),
         'features'       => array('MCPD' => 'yes', 'MCPD-version' => 'V.' . BRAPI_MCPD_VERSION),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'germplasm/{germplasmDbId}' => array(
         'title'          => 'Germplasm Details',
@@ -418,7 +418,7 @@ function brapi_get_calls() {
           ),
         ),
         'features'       => array('MCPD' => 'yes', 'MCPD-version' => 'V.' . BRAPI_MCPD_VERSION),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'germplasm/{germplasmDbId}/attributes' => array(
         'title'          => 'Germplasm Attributes',
@@ -440,7 +440,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'germplasm/{germplasmDbId}/markerprofiles' => array(
         'title'          => 'Germplasm Markerprofiles',
@@ -462,7 +462,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'germplasm/{germplasmDbId}/pedigree' => array(
         'title'          => 'Germplasm Pedigree',
@@ -485,7 +485,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'germplasm-search' => array(
         'title'          => 'Germplasm Search',
@@ -573,7 +573,7 @@ function brapi_get_calls() {
           ),
         ),
         'features'       => array('MCPD' => 'yes', 'MCPD-version' => 'V.' . BRAPI_MCPD_VERSION),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'locations' => array(
         'title'          => 'Locations',
@@ -588,7 +588,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_location_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'locations/{locationDbId}' => array(
         'title'          => 'Locations Details',
@@ -610,7 +610,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_location_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'maps'      => array(
         'title'          => 'Genome Map',
@@ -625,7 +625,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'maps/{mapDbId}' => array(
         'title'          => 'Genome Map Details',
@@ -640,7 +640,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'maps/{mapDbId}/positions' => array(
         'title'          => 'Genome map data',
@@ -655,7 +655,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'maps/{mapDbId}/positions/{linkageGroupName}' => array(
         'title'          => 'Genome Map Data by range on linkageGroup',
@@ -670,7 +670,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'markerprofiles'      => array(
         'title'          => 'Markerprofile Search',
@@ -685,7 +685,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'markerprofiles/{markerprofileDbId}' => array(
         'title'          => 'Marker profiles',
@@ -700,7 +700,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'markers' => array(
         'title'          => 'Marker List',
@@ -715,7 +715,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_marker_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'markers/{markerDbId}' => array(
         'title'          => 'Marker Details',
@@ -737,7 +737,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'markers-search'      => array(
         'title'          => 'Markers Search',
@@ -752,7 +752,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_marker_search_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'observationlevels' => array(
         'title'          => 'Observation Level List',
@@ -767,7 +767,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'ontologies' => array(
         'title'          => 'Variable ontology list',
@@ -782,7 +782,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'phenotypes-search'      => array(
         'title'          => 'Phenotype Search',
@@ -797,7 +797,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'phenotypes'      => array(
         'title'          => 'Phenotype List',
@@ -812,7 +812,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'phenotypes/{phenotypeDbId}' => array(
         'title'          => 'Phenotype Details',
@@ -835,7 +835,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'programs'      => array(
         'title'          => 'Program List',
@@ -850,7 +850,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_program_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'programs/{programDbId}' => array(
         'title'          => 'Program Details',
@@ -872,7 +872,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'programs-search'      => array(
         'title'          => 'Program Search',
@@ -887,7 +887,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_program_search_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'samples' => array(
         'title'          => 'Sample List',
@@ -902,7 +902,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_sample_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'samples/{sampleDbId}' => array(
         'title'          => 'Sample Details',
@@ -927,7 +927,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'samples-search' => array(
         'title'          => 'Sample Search',
@@ -942,7 +942,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_sample_search_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'seasons'      => array(
         'title'          => 'Season List',
@@ -957,7 +957,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'studies'      => array(
         'title'          => 'Study List',
@@ -972,7 +972,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'studies/{studyDbId}'      => array(
         'title'          => 'Study Details',
@@ -995,7 +995,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'studies/{studyDbId}/germplasm'      => array(
         'title'          => 'Study Germplasm Details',
@@ -1018,7 +1018,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'studies/{studyDbId}/layout'      => array(
         'title'          => 'Plot Layout Details',
@@ -1041,7 +1041,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'studies/{studyDbId}/observations'      => array(
         'title'          => 'Observations Details',
@@ -1064,7 +1064,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'studies/{studyDbId}/observationunits'      => array(
         'title'          => 'Observation Units Details',
@@ -1087,7 +1087,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'studies/{studyDbId}/observationvariables'      => array(
         'title'          => 'Study Observation Variables',
@@ -1110,7 +1110,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'studies/{studyDbId}/table'      => array(
         'title'          => 'Study Observation Units as a Table',
@@ -1133,7 +1133,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'studies-search'      => array(
         'title'          => 'Study search',
@@ -1148,7 +1148,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'studytypes'      => array(
         'title'          => 'Study Type List',
@@ -1163,7 +1163,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'token'      => array(
         'title'          => 'Authentication',
@@ -1180,7 +1180,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_authentication_json',
           '1.1' => 'brapi_v1_authentication_json',
         ),
-        'aggregable' => FALSE,
+        'aggregatable' => FALSE,
       ),
       'traits'      => array(
         'title'          => 'Trait List',
@@ -1195,7 +1195,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'traits/{traitDbId}' => array(
         'title'          => 'Trait Details',
@@ -1218,7 +1218,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'trials'      => array(
         'title'          => 'Trial List',
@@ -1233,7 +1233,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'trials/{trialDbId}' => array(
         'title'          => 'Trial Details',
@@ -1256,7 +1256,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'variables'      => array(
         'title'          => 'Variable List',
@@ -1271,7 +1271,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_variable_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'variables/{observationVariableDbId}' => array(
         'title'          => 'Variable Details',
@@ -1294,7 +1294,7 @@ function brapi_get_calls() {
             'required' => FALSE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'variables/datatypes' => array(
         'title'          => 'Variable Data Types',
@@ -1310,7 +1310,7 @@ function brapi_get_calls() {
           '1.0' => 'brapi_v1_variable_datatypes_json',
           '1.1' => 'brapi_v1_variable_datatypes_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'variables-search' => array(
         'title'          => 'Variable Search',
@@ -1325,7 +1325,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_variable_search_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'vendors/plates/{vendorPlateDbId}' => array(
         'title'          => 'Plate Details',
@@ -1348,7 +1348,7 @@ function brapi_get_calls() {
             'required' => TRUE,
           ),
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'vendors/plates-search' => array(
         'title'          => 'Plate Search',
@@ -1363,7 +1363,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
       'vendors/specifications' => array(
         'title'          => 'Vendor Specifications',
@@ -1378,7 +1378,7 @@ function brapi_get_calls() {
         'callback versions' => array(
           '1.1' => 'brapi_v1_external_call_json',
         ),
-        'aggregable' => TRUE,
+        'aggregatable' => TRUE,
       ),
     );
 
@@ -2788,6 +2788,12 @@ function brapi_get_data_mapping() {
           break;
 
         case 'speciesOrganism':
+          $germplasm_fields['species']['alias_for'] = 'speciesOrganism';
+          $germplasm_fields['speciesAuthority']['alias_for'] = 'speciesAuthorityProp';
+          $germplasm_fields['subtaxa']['alias_for'] = 'subtaxaProp';
+          $germplasm_fields['subtaxaAuthority']['alias_for'] = 'subtaxaAuthorityProp';
+          break;
+          
         default:
           $germplasm_fields['species']['alias_for'] = 'speciesFunc';
           $germplasm_fields['speciesAuthority']['alias_for'] = 'speciesAuthorityFunc';

--- a/api/brapi.const.inc
+++ b/api/brapi.const.inc
@@ -1821,8 +1821,16 @@ function brapi_get_data_mapping() {
                 break;
 
               case 'read':
-                if ($nid = chado_get_nid_from_id('stock', $stock->stock_id)) {
-                  $germplasm_pui = $base_url . '/' . drupal_get_path_alias('node/' . $nid);
+                $pui = NULL;
+                // Tripal 2.
+                if (function_exists('chado_get_nid_from_id')) {
+                  $pui = chado_get_nid_from_id('stock', $stock->stock_id);
+                  $germplasm_pui = $base_url . '/' . drupal_get_path_alias('node/' . $pui);
+                }
+                // Tripal 3.
+                if (function_exists('chado_get_record_entity_by_table')) {
+                  $pui = chado_get_record_entity_by_table('stock', $stock->stock_id);
+                  $germplasm_pui = $base_url . '/' . drupal_get_path_alias('bio_data/' . $pui);
                 }
                 break;
 

--- a/brapi.info
+++ b/brapi.info
@@ -8,5 +8,3 @@ dependencies[] = brapi_site
 
 scripts[] = theme/js/brapi.js
 
-files[] = brapi.test
-

--- a/brapi.install
+++ b/brapi.install
@@ -226,7 +226,7 @@ function brapi_uninstall() {
   // Remove BrAPI CVs.
   brapi_remove_cvs();
   // Notify MCPD CV has not been removed.
-  drupal_set_message($t("BrAPI: MCPD vocabulary has not been removed from Chado. If you don't need it anymore, you can remove it manually using the following SQL query: \"DELETE FROM chado.cv cv WHERE cv.name = '" . BRAPI_CV . "';\""));
+  drupal_set_message($t("BrAPI: MCPD vocabulary has not been removed from Chado. If you don't need it anymore, you can remove it manually using the following SQL query: \"DELETE FROM chado.cv cv WHERE cv.name = '" . BRAPI_MULTICROP_PASSPORT_ONTOLOGY_CV . "';\""));
   // Clear BrAPI settings.
   variable_del(BRAPI_AGGREGATION_OPTIONS);
   variable_del(BRAPI_CUSTOM_DATE_FORMAT);

--- a/brapi.install
+++ b/brapi.install
@@ -251,10 +251,15 @@ function brapi_load_obo($name, $file) {
     }
     $return = $obo_id;
   }
-  elseif (module_exists('tripal_cv')) {
+  elseif (module_exists('tripal_cv') && function_exists('tripal_cv_load_obo_v1_2')) {
     // Tripal v2.
     $newcvs = array();
     $return = tripal_cv_load_obo_v1_2($file, NULL, $newcvs);
+  }
+  else {
+    throw new Exception(t(
+      "Unable to find a way to load MCPD OBO file!"
+    ));
   }
 
   return $return;

--- a/brapi.install
+++ b/brapi.install
@@ -243,12 +243,7 @@ function brapi_uninstall() {
  */
 function brapi_load_obo($name, $file) {
   $return = FALSE;
-  if (module_exists('tripal_cv')) {
-    // Tripal v2.
-    $newcvs = array();
-    $return = tripal_cv_load_obo_v1_2($file, NULL, $newcvs);
-  }
-  else if (module_exists('tripal_chado')) {
+  if (module_exists('tripal_chado')) {
     module_load_include('inc', 'tripal_chado', 'includes/tripal_chado.cv');
     // Tripal v3.
     if ($obo_id = chado_insert_obo($name, $file)) {
@@ -256,6 +251,12 @@ function brapi_load_obo($name, $file) {
     }
     $return = $obo_id;
   }
+  elseif (module_exists('tripal_cv')) {
+    // Tripal v2.
+    $newcvs = array();
+    $return = tripal_cv_load_obo_v1_2($file, NULL, $newcvs);
+  }
+
   return $return;
 }
 

--- a/cv/mcpd_v2.1_151215.obo
+++ b/cv/mcpd_v2.1_151215.obo
@@ -772,15 +772,6 @@ is_a: CO_020:0000107 ! MLS status of the accession
 created_by: lvalette
 creation_date: 2015-07-01T16:56:21Z
 
-[Term]
-id: ID:0000000
-name: persistent unique identifier
-comment: Any persistent, unique identifier assigned to the accession so it can be unambiguously referenced at the global level and the information associated with it harvested through automated means. Report one PUID for each accession. \n\nThe Secretariat of the International Treaty on Plant Genetic Resources for Food and Agriculture (PGRFA) is facilitating the assignment of a persistent unique identifier (PUID), in the form of  a DOI, to PGRFA at the accession level (http://www.planttreaty.org/doi). \nGenebanks not applying a true PUID to their accessions should use, and request recipients to use, the concatenation of INSTCODE, ACCENUMB, and GENUS as a globally unique identifier \nsimilar in most respects to the PUID whenever they exchange information on accessions with third parties (e.g. NOR017:NGB17773:ALLIUM).
-synonym: "PUID" RELATED []
-is_a: CO_020:0000074 ! multicrop passport descriptor
-created_by: lvalette
-creation_date: 2015-12-15T09:38:00Z
-
 [Typedef]
 id: CO_020:0000001
 name: range_of

--- a/cv/mcpd_v2.1_151215.obo
+++ b/cv/mcpd_v2.1_151215.obo
@@ -11,6 +11,14 @@ name: multicrop passport ontology
 comment: release date: June 30, 2015\nversion: 2.1. Adapted from FAO/Bioversity Multi-Crop Passport Descriptors, December 2015\ncoverage: Multi-Crop Passport Descriptors\ncreator: Jeffrey Detras, Tom Hazekamp and Richard Bruskiewich, updated by Leo Valette\npublisher: Bioversity International and IRRI under the Generation Challenge Program
 xref: GCPDomainModel:CO_000\:0000165
 
+[Typedef]
+id: CO_020:0000001
+name: range_of
+
+[Typedef]
+id: CO_020:0000002
+name: descriptor_of
+
 [Term]
 id: CO_020:0000003
 name: collecting number
@@ -771,12 +779,3 @@ comment: Elaborate in REMARKS field e.g., "under development"
 is_a: CO_020:0000107 ! MLS status of the accession
 created_by: lvalette
 creation_date: 2015-07-01T16:56:21Z
-
-[Typedef]
-id: CO_020:0000001
-name: range_of
-
-[Typedef]
-id: CO_020:0000002
-name: descriptor_of
-

--- a/cv/mcpd_v2.1_151215.obo
+++ b/cv/mcpd_v2.1_151215.obo
@@ -3,7 +3,7 @@ date: 15:12:2015 09:57
 saved-by: lvalette
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: multicrop passport ontology
-ontology: MCPD
+ontology: CO_020
 
 [Term]
 id: CO_020:0000000

--- a/cv/mcpd_v2.1_151215.obo
+++ b/cv/mcpd_v2.1_151215.obo
@@ -3,6 +3,7 @@ date: 15:12:2015 09:57
 saved-by: lvalette
 auto-generated-by: OBO-Edit 2.3.1
 default-namespace: multicrop passport ontology
+ontology: MCPD
 
 [Term]
 id: CO_020:0000000

--- a/includes/brapi.admin.inc
+++ b/includes/brapi.admin.inc
@@ -300,33 +300,50 @@ function brapi_admin_form($form, &$form_state, $no_js_use = FALSE) {
 
   $brapi_cv_settings = brapi_get_cv_settings();
   foreach (brapi_get_cv() as $term_name => $definition) {
-    $default_id = 0;
-    $term = NULL;
+    $default_ids = array();
 
     // Get from settings.
     if (array_key_exists($term_name, $brapi_cv_settings)) {
-      $default_id = $brapi_cv_settings[$term_name];
-      $term = tripal_get_cvterm(array('cvterm_id' => $default_id));
+      $default_ids = $brapi_cv_settings[$term_name];
+      if ($default_ids) {
+        if (!is_array($default_ids)) {
+          $default_ids = array_map('trim', explode(',', $default_ids));
+        }
+      }
+      else {
+        $default_ids = array();
+      }
     }
 
-    // Get term from BrAPI CV.
-    if (!$term) {
-      $term =
-        tripal_get_cvterm(
-          array('name' => $term_name, 'cv_id' => $brapi_cv->cv_id)
-        );
+    // Get term from MCPD CV.
+    if (empty($default_ids)) {
+      $default_ids = brapi_get_cvterm_id($term_mapping);
     }
 
-    if ($term) {
-      $default_id =
-        $term->name
-        . ' (cv:' . $term->cv_id->name . '; id:' . $term->cvterm_id . ')';
+    if (!empty($default_ids)) {
+      $terms = chado_generate_var(
+        'cvterm',
+        array('cvterm_id' => $default_ids),
+        array('return_array' => 1)
+      );
+      // Turn numeric ids into human-readable values.
+      $default_ids = array();
+      foreach ($terms as $term) {
+        $default_ids[] =
+          $term->name
+          . ' (cv:' . $term->cv_id->name . '; id:' . $term->cvterm_id . ')';
+      }
+    }
+
+    // Set a default id for missing terms.
+    if (empty($default_ids)) {
+      $default_ids = array(0);
     }
 
     $form['cv_settings'][$term_name] = array(
       '#type' => 'textfield',
       '#description' => $definition,
-      '#default_value' => $default_id,
+      '#default_value' => implode(', ', $default_ids),
       '#autocomplete_path' => 'brapi/terms/autocomplete',
       '#title' => $term_name,
       '#title_display' => 'before',
@@ -769,14 +786,32 @@ function brapi_admin_form_submit($form_id, &$form_state) {
   // CV settings.
   $brapi_cv_settings = brapi_get_cv_settings();
   foreach (brapi_get_cv() as $term_label => $definition) {
-    $user_term = $form_state['values'][$term_label];
-    $cvterm_id = brapi_get_cvterm_id($user_term, FALSE);
-    if ($cvterm_id) {
-      $brapi_cv_settings[$term_label] = $cvterm_id;
+    $user_terms = $form_state['values'][$term_label];
+    $user_term_array = array_filter(array_map(
+      function ($a) {
+        return trim(str_replace("\\,", ',', $a));
+      },
+      preg_split('/(?<!\\\\),/', $user_terms)
+    ));
+    $cvterm_ids = array();
+    foreach ($user_term_array as $user_term) {
+      $cvterm_id = brapi_get_cvterm_id($user_term, FALSE);
+      if ($cvterm_id) {
+        $cvterm_ids[$cvterm_id] = $cvterm_id;
+      }
+      else {
+        drupal_set_message(t('Term not found: "@term_label"', array('@term_label' => $term_label)), 'warning');
+      }
+    }
+
+    if (empty($cvterm_ids)) {
+      $brapi_cv_settings[$term_label] = 0;
+    }
+    elseif (1 == count($cvterm_ids)){
+      $brapi_cv_settings[$term_label] = array_values($cvterm_ids)[0];
     }
     else {
-      $brapi_cv_settings[$term_label] = 0;
-      drupal_set_message(t('Term not found: "@term_label"', array('@term_label' => $term_label)), 'warning');
+      $brapi_cv_settings[$term_label] = array_values($cvterm_ids);
     }
   }
 
@@ -784,8 +819,14 @@ function brapi_admin_form_submit($form_id, &$form_state) {
   foreach (brapi_get_mcpd_settings() as $term_label => $term_mapping) {
     $term_machine_name = preg_replace('/\W+/', '_', $term_label);
     $user_terms = $form_state['values'][$term_machine_name];
+    $user_term_array = array_filter(array_map(
+      function ($a) {
+        return trim(str_replace("\\,", ',', $a));
+      },
+      preg_split('/(?<!\\\\),/', $user_terms)
+    ));
     $cvterm_ids = array();
-    foreach (array_map('trim', explode(',', $user_terms)) as $user_term) {
+    foreach ($user_term_array as $user_term) {
       if ($user_term) {
         $cvterm_id = brapi_get_cvterm_id($user_term);
         if (!$cvterm_id) {
@@ -800,13 +841,14 @@ function brapi_admin_form_submit($form_id, &$form_state) {
       }
     }
 
-    if (!empty($cvterm_ids)) {
-      if (1 == count($cvterm_ids)) {
-        $brapi_cv_settings[$term_label] = array_values($cvterm_ids)[0];
-      }
-      else {
-        $brapi_cv_settings[$term_label] = array_values($cvterm_ids);
-      }
+    if (empty($cvterm_ids)) {
+      $brapi_cv_settings[$term_label] = 0;
+    }
+    elseif (1 == count($cvterm_ids)){
+      $brapi_cv_settings[$term_label] = array_values($cvterm_ids)[0];
+    }
+    else {
+      $brapi_cv_settings[$term_label] = array_values($cvterm_ids);
     }
   }
   // Save CV settings.

--- a/includes/brapi.admin.inc
+++ b/includes/brapi.admin.inc
@@ -835,27 +835,29 @@ function brapi_admin_form_submit($form_id, &$form_state) {
   $germplasm_attributes = array();
   $germplasm_category_list = variable_get(BRAPI_GERMPLASM_ATTR_CATEGORIES, array());
   $germplasm_categories = array_flip($germplasm_category_list);
-  foreach ($form_state['values']['attribute'] as $attribute) {
-    if ($attribute['name']
-        && ($attribute['cvs'] || $attribute['cvterms'])) {
-      // Replace category name by its index.
-      if (array_key_exists($attribute['category'], $germplasm_categories)) {
-        // Get existing index.
-        $attribute['category'] = $germplasm_categories[$attribute['category']];
+  if (!empty($form_state['values']['attribute'])) {
+    foreach ($form_state['values']['attribute'] as $attribute) {
+      if ($attribute['name']
+          && ($attribute['cvs'] || $attribute['cvterms'])) {
+        // Replace category name by its index.
+        if (array_key_exists($attribute['category'], $germplasm_categories)) {
+          // Get existing index.
+          $attribute['category'] = $germplasm_categories[$attribute['category']];
+        }
+        else {
+          // Category does not exist, add it.
+          $germplasm_category_list[] = $attribute['category'];
+          // Place array index on last inserted key.
+          end($germplasm_category_list);
+          // Save index.
+          $attribute['category'] =
+            $germplasm_categories[$attribute['category']] =
+            key($germplasm_category_list);
+        }
+        $germplasm_attributes[] = $attribute;
       }
-      else {
-        // Category does not exist, add it.
-        $germplasm_category_list[] = $attribute['category'];
-        // Place array index on last inserted key.
-        end($germplasm_category_list);
-        // Save index.
-        $attribute['category'] =
-          $germplasm_categories[$attribute['category']] =
-          key($germplasm_category_list);
-      }
-      $germplasm_attributes[] = $attribute;
+    
     }
-
   }
   variable_set(BRAPI_GERMPLASM_ATTRIBUTES, $germplasm_attributes);
   variable_set(BRAPI_GERMPLASM_ATTR_CATEGORIES, $germplasm_category_list);

--- a/includes/brapi.admin.inc
+++ b/includes/brapi.admin.inc
@@ -659,7 +659,7 @@ function brapi_admin_form($form, &$form_state, $no_js_use = FALSE) {
       '#multiple' => FALSE,
     );
 
-    if ($call['aggregatable']) {
+    if ($call['aggregable']) {
       $default_values =
         (isset($aggregation_options[$call_path])
             && $aggregation_options[$call_path]) ?
@@ -917,7 +917,7 @@ function brapi_admin_form_submit($form_id, &$form_state) {
     }
     $call_path_form_name = preg_replace('/\W+/', '_', $call_path);
     $version_options[$call_path] = $form_state['values']['version_' . $call_path_form_name];
-    if ($call['aggregatable']) {
+    if ($call['aggregable']) {
       $brapi_aggregation_options[$call_path] = array_keys($form_state['values']['aggr_' . $call_path_form_name]);
     }
   }

--- a/includes/brapi.admin.inc
+++ b/includes/brapi.admin.inc
@@ -394,6 +394,11 @@ function brapi_admin_form($form, &$form_state, $no_js_use = FALSE) {
       }
     }
 
+    // Set a default id for missing terms.
+    if (empty($default_ids)) {
+      $default_ids = array(0);
+    }
+
     if (array_key_exists('name', $term_mapping)) {
       $description = t(
         '<b>"@mcpd_term"</b> is the MCPD term that should be used for this field.',

--- a/includes/brapi.admin.inc
+++ b/includes/brapi.admin.inc
@@ -159,7 +159,8 @@ function brapi_admin_form($form, &$form_state, $no_js_use = FALSE) {
   // Species storage.
   $species_options = array(
     'speciesProp' => t('Stored in stockprop table'),
-    'speciesOrganism' => t('Stored in organism + phylonode tables'),
+    'speciesOrganism' => t('Stored in organism table'),
+    'speciesFunc' => t('Stored in organism + phylonode tables'),
   );
   $species_storage = isset($storage_options['species']) ?
     $storage_options['species']
@@ -300,50 +301,33 @@ function brapi_admin_form($form, &$form_state, $no_js_use = FALSE) {
 
   $brapi_cv_settings = brapi_get_cv_settings();
   foreach (brapi_get_cv() as $term_name => $definition) {
-    $default_ids = array();
+    $default_id = 0;
+    $term = NULL;
 
     // Get from settings.
     if (array_key_exists($term_name, $brapi_cv_settings)) {
-      $default_ids = $brapi_cv_settings[$term_name];
-      if ($default_ids) {
-        if (!is_array($default_ids)) {
-          $default_ids = array_map('trim', explode(',', $default_ids));
-        }
-      }
-      else {
-        $default_ids = array();
-      }
+      $default_id = $brapi_cv_settings[$term_name];
+      $term = tripal_get_cvterm(array('cvterm_id' => $default_id));
     }
 
-    // Get term from MCPD CV.
-    if (empty($default_ids)) {
-      $default_ids = brapi_get_cvterm_id($term_mapping);
+    // Get term from BrAPI CV.
+    if (!$term) {
+      $term =
+        tripal_get_cvterm(
+          array('name' => $term_name, 'cv_id' => $brapi_cv->cv_id)
+        );
     }
 
-    if (!empty($default_ids)) {
-      $terms = chado_generate_var(
-        'cvterm',
-        array('cvterm_id' => $default_ids),
-        array('return_array' => 1)
-      );
-      // Turn numeric ids into human-readable values.
-      $default_ids = array();
-      foreach ($terms as $term) {
-        $default_ids[] =
-          $term->name
-          . ' (cv:' . $term->cv_id->name . '; id:' . $term->cvterm_id . ')';
-      }
-    }
-
-    // Set a default id for missing terms.
-    if (empty($default_ids)) {
-      $default_ids = array(0);
+    if ($term) {
+      $default_id =
+        $term->name
+        . ' (cv:' . $term->cv_id->name . '; id:' . $term->cvterm_id . ')';
     }
 
     $form['cv_settings'][$term_name] = array(
       '#type' => 'textfield',
       '#description' => $definition,
-      '#default_value' => implode(', ', $default_ids),
+      '#default_value' => $default_id,
       '#autocomplete_path' => 'brapi/terms/autocomplete',
       '#title' => $term_name,
       '#title_display' => 'before',
@@ -409,11 +393,6 @@ function brapi_admin_form($form, &$form_state, $no_js_use = FALSE) {
           $term->name
           . ' (cv:' . $term->cv_id->name . '; id:' . $term->cvterm_id . ')';
       }
-    }
-
-    // Set a default id for missing terms.
-    if (empty($default_ids)) {
-      $default_ids = array(0);
     }
 
     if (array_key_exists('name', $term_mapping)) {
@@ -659,7 +638,7 @@ function brapi_admin_form($form, &$form_state, $no_js_use = FALSE) {
       '#multiple' => FALSE,
     );
 
-    if ($call['aggregable']) {
+    if ($call['aggregatable']) {
       $default_values =
         (isset($aggregation_options[$call_path])
             && $aggregation_options[$call_path]) ?
@@ -786,32 +765,14 @@ function brapi_admin_form_submit($form_id, &$form_state) {
   // CV settings.
   $brapi_cv_settings = brapi_get_cv_settings();
   foreach (brapi_get_cv() as $term_label => $definition) {
-    $user_terms = $form_state['values'][$term_label];
-    $user_term_array = array_filter(array_map(
-      function ($a) {
-        return trim(str_replace("\\,", ',', $a));
-      },
-      preg_split('/(?<!\\\\),/', $user_terms)
-    ));
-    $cvterm_ids = array();
-    foreach ($user_term_array as $user_term) {
-      $cvterm_id = brapi_get_cvterm_id($user_term, FALSE);
-      if ($cvterm_id) {
-        $cvterm_ids[$cvterm_id] = $cvterm_id;
-      }
-      else {
-        drupal_set_message(t('Term not found: "@term_label"', array('@term_label' => $term_label)), 'warning');
-      }
-    }
-
-    if (empty($cvterm_ids)) {
-      $brapi_cv_settings[$term_label] = 0;
-    }
-    elseif (1 == count($cvterm_ids)){
-      $brapi_cv_settings[$term_label] = array_values($cvterm_ids)[0];
+    $user_term = $form_state['values'][$term_label];
+    $cvterm_id = brapi_get_cvterm_id($user_term, FALSE);
+    if ($cvterm_id) {
+      $brapi_cv_settings[$term_label] = $cvterm_id;
     }
     else {
-      $brapi_cv_settings[$term_label] = array_values($cvterm_ids);
+      $brapi_cv_settings[$term_label] = 0;
+      drupal_set_message(t('Term not found: "@term_label"', array('@term_label' => $term_label)), 'warning');
     }
   }
 
@@ -819,14 +780,8 @@ function brapi_admin_form_submit($form_id, &$form_state) {
   foreach (brapi_get_mcpd_settings() as $term_label => $term_mapping) {
     $term_machine_name = preg_replace('/\W+/', '_', $term_label);
     $user_terms = $form_state['values'][$term_machine_name];
-    $user_term_array = array_filter(array_map(
-      function ($a) {
-        return trim(str_replace("\\,", ',', $a));
-      },
-      preg_split('/(?<!\\\\),/', $user_terms)
-    ));
     $cvterm_ids = array();
-    foreach ($user_term_array as $user_term) {
+    foreach (array_map('trim', explode(',', $user_terms)) as $user_term) {
       if ($user_term) {
         $cvterm_id = brapi_get_cvterm_id($user_term);
         if (!$cvterm_id) {
@@ -841,14 +796,13 @@ function brapi_admin_form_submit($form_id, &$form_state) {
       }
     }
 
-    if (empty($cvterm_ids)) {
-      $brapi_cv_settings[$term_label] = 0;
-    }
-    elseif (1 == count($cvterm_ids)){
-      $brapi_cv_settings[$term_label] = array_values($cvterm_ids)[0];
-    }
-    else {
-      $brapi_cv_settings[$term_label] = array_values($cvterm_ids);
+    if (!empty($cvterm_ids)) {
+      if (1 == count($cvterm_ids)) {
+        $brapi_cv_settings[$term_label] = array_values($cvterm_ids)[0];
+      }
+      else {
+        $brapi_cv_settings[$term_label] = array_values($cvterm_ids);
+      }
     }
   }
   // Save CV settings.
@@ -877,29 +831,27 @@ function brapi_admin_form_submit($form_id, &$form_state) {
   $germplasm_attributes = array();
   $germplasm_category_list = variable_get(BRAPI_GERMPLASM_ATTR_CATEGORIES, array());
   $germplasm_categories = array_flip($germplasm_category_list);
-  if (!empty($form_state['values']['attribute'])) {
-    foreach ($form_state['values']['attribute'] as $attribute) {
-      if ($attribute['name']
-          && ($attribute['cvs'] || $attribute['cvterms'])) {
-        // Replace category name by its index.
-        if (array_key_exists($attribute['category'], $germplasm_categories)) {
-          // Get existing index.
-          $attribute['category'] = $germplasm_categories[$attribute['category']];
-        }
-        else {
-          // Category does not exist, add it.
-          $germplasm_category_list[] = $attribute['category'];
-          // Place array index on last inserted key.
-          end($germplasm_category_list);
-          // Save index.
-          $attribute['category'] =
-            $germplasm_categories[$attribute['category']] =
-            key($germplasm_category_list);
-        }
-        $germplasm_attributes[] = $attribute;
+  foreach ($form_state['values']['attribute'] as $attribute) {
+    if ($attribute['name']
+        && ($attribute['cvs'] || $attribute['cvterms'])) {
+      // Replace category name by its index.
+      if (array_key_exists($attribute['category'], $germplasm_categories)) {
+        // Get existing index.
+        $attribute['category'] = $germplasm_categories[$attribute['category']];
       }
-    
+      else {
+        // Category does not exist, add it.
+        $germplasm_category_list[] = $attribute['category'];
+        // Place array index on last inserted key.
+        end($germplasm_category_list);
+        // Save index.
+        $attribute['category'] =
+          $germplasm_categories[$attribute['category']] =
+          key($germplasm_category_list);
+      }
+      $germplasm_attributes[] = $attribute;
     }
+
   }
   variable_set(BRAPI_GERMPLASM_ATTRIBUTES, $germplasm_attributes);
   variable_set(BRAPI_GERMPLASM_ATTR_CATEGORIES, $germplasm_category_list);
@@ -917,7 +869,7 @@ function brapi_admin_form_submit($form_id, &$form_state) {
     }
     $call_path_form_name = preg_replace('/\W+/', '_', $call_path);
     $version_options[$call_path] = $form_state['values']['version_' . $call_path_form_name];
-    if ($call['aggregable']) {
+    if ($call['aggregatable']) {
       $brapi_aggregation_options[$call_path] = array_keys($form_state['values']['aggr_' . $call_path_form_name]);
     }
   }

--- a/theme/brapi.theme.inc
+++ b/theme/brapi.theme.inc
@@ -38,7 +38,7 @@ function brapi_theme_compute_role_stats($permission) {
     $result = db_query($query);
     $user_count = $result->fetchCol()[0];
   }
-  else {
+  elseif (!empty($user_roles)) {
     // Get users count.
     $query = 'SELECT COUNT(DISTINCT(ur.uid))
       FROM {users_roles} ur
@@ -46,6 +46,9 @@ function brapi_theme_compute_role_stats($permission) {
       WHERE r.name IN (:roles);';
     $result = db_query($query, array(':roles' => $user_roles));
     $user_count = $result->fetchCol()[0];
+  }
+  else {
+    $user_count = 0;
   }
 
   // Change display of special roles.


### PR DESCRIPTION
The 'genus' data mapping is set to 'genusOrganism' or 'genusProp' depending on the data mapping on the admin page. On the other hand, 'species' data mapping is set to either 'speciesProp' or 'speciesFunc'. 'speciesFunc' calls `brapi_get_organism_info()`, which makes an SQL query which expects to find the species via a phylonode rather than directly from the organism record. 

PeanutBase data isn't stored this way. Here I modified the code so that 'speciesOrganism' will work like 'genusOrganism' rather than it being re-assigned to 'speciesFunc' by adding 'organism table' as an option on the admin page and changing the code that set 'speciesOrganism' to 'speciesFunc' in api/brapi.const.inc.
