### PR TITLE
7.x issue #38 Alternatives to species method for generating crop names

### DIFF
--- a/api/brapi.calls.inc
+++ b/api/brapi.calls.inc
@@ -2094,20 +2094,66 @@ function brapi_v1_crops_10_json() {
   $crop_list = array();
 
   $storage_options = variable_get(BRAPI_STORAGE_OPTIONS, array());
+  $naming_method = 'nameBySpecies';
+  if (isset($storage_options['crop_naming_method'])) {
+    $naming_method = $storage_options['crop_naming_method'];
+  }
+
   if (isset($storage_options['crop_list'])
       && !empty($storage_options['crop_list'])) {
     $crop_list = explode(',', $storage_options['crop_list']);
   }
   else {
-    $sql_query = "
-      SELECT species
-      FROM {organism} o
-      WHERE EXISTS
-        (SELECT TRUE FROM {stock} s WHERE s.organism_id = o.organism_id LIMIT 1)
-      ORDER BY species;";
+    if ($naming_method == 'nameByAbbreviation') {
+      $sql_query = "
+        SELECT abbreviation AS name, CONCAT_WS(' ', genus, species) AS altname, organism_id
+        FROM {organism} o
+        WHERE EXISTS
+          (SELECT TRUE FROM {stock} s WHERE s.organism_id = o.organism_id LIMIT 1)
+        ORDER BY abbreviation;";
+    }
+    else if ($naming_method == 'nameByCommonName') {
+      $sql_query = "
+        SELECT common_name AS name, CONCAT_WS(' ', genus, species) AS altname, organism_id
+        FROM {organism} o
+        WHERE EXISTS
+          (SELECT TRUE FROM {stock} s WHERE s.organism_id = o.organism_id LIMIT 1)
+        ORDER BY common_name;";
+    }
+    else if ($naming_method == 'nameByTaxon') {
+      $sql_query = "
+        SELECT NULL AS name, CONCAT_WS(' ', genus, species) AS altname, organism_id
+        FROM {organism} o
+        WHERE EXISTS
+          (SELECT TRUE FROM {stock} s WHERE s.organism_id = o.organism_id LIMIT 1)
+        ORDER BY genus, species;";
+    }
+    else {
+      $sql_query = "
+        SELECT species AS name, NULL AS altname
+        FROM {organism} o
+        WHERE EXISTS
+          (SELECT TRUE FROM {stock} s WHERE s.organism_id = o.organism_id LIMIT 1)
+        ORDER BY species;";
+    }
+
     $crop_result = chado_query($sql_query);
+    // Determine if we can lookup infraspecific nomenclature (chado>=1.3).
+    $can_lookup_taxon = function_exists('chado_get_organism_scientific_name');
     while ($crop = $crop_result->fetchAssoc()) {
-      $crop_list[] = $crop['species'];
+      $name = $crop['name'];
+      $altname = $crop['altname'];
+      // SQL ensures that if $name is missing for common_name or abbreviation, $altname will have a value.
+      if (!$name) {
+        if ($can_lookup_taxon) {
+          $organism_id = $crop['organism_id'];
+          $name = chado_get_organism_scientific_name(chado_get_organism(['organism_id' => $organism_id], []));
+        }
+        else {
+          $name = $altname;
+        }
+      }
+      $crop_list[] = $name;
     }
   }
   $data = array('result' => array('data' => $crop_list));

--- a/includes/brapi.admin.inc
+++ b/includes/brapi.admin.inc
@@ -120,15 +120,41 @@ function brapi_admin_form($form, &$form_state, $no_js_use = FALSE) {
     '#required' => TRUE,
     '#multiple' => FALSE,
   );
-  // Crop list storage.
+  // Crop list storage. Naming method selection, and manual override list.
+  $crop_naming_method_options = array(
+    'nameBySpecies' => t('Use species as crop name'),
+    'nameByAbbreviation' => t('Use organism abbreviation as crop name'),
+    'nameByCommonName' => t('Use organism common name as crop name'),
+    'nameByTaxon' => t('Use full taxon as crop name'),
+  );
+  $crop_naming_method = isset($storage_options['crop_naming_method']) ?
+    $storage_options['crop_naming_method']
+    : '';
+  if (!$crop_naming_method
+      || (($crop_naming_method != 'nameBySpecies')
+          && ($crop_naming_method != 'nameByAbbreviation')
+          && ($crop_naming_method != 'nameByCommonName')
+          && ($crop_naming_method != 'nameByTaxon'))) {
+    $crop_naming_method = 'nameBySpecies';
+  }
+  $form['storage_options']['crop_naming_method'] = array(
+    '#type' => 'select',
+    '#description' => t('Select the way a crop name is generated for each organism. If the selected method returns no value for an organism, the full taxon will then be used.'),
+    '#options' => $crop_naming_method_options,
+    '#default_value' => $crop_naming_method,
+    '#title' => t('Crop naming method'),
+    '#title_display' => 'before',
+    '#required' => TRUE,
+    '#multiple' => FALSE,
+  );
   $crop_list_storage = isset($storage_options['crop_list']) ?
     $storage_options['crop_list']
     : '';
   $form['storage_options']['crop_list'] = array(
     '#type' => 'textfield',
-    '#description' => t('Enter the list of (no space coma-separated) supported crops here or leave this field empty to use the Chado organism.species field values.'),
+    '#description' => t('Enter the list of (no space, comma-separated) supported crops here. If blank, the "Crop naming method" selected above will be used.'),
     '#default_value' => $crop_list_storage,
-    '#title' => t('List of supported crops ("crops" call)'),
+    '#title' => t('Manual entry of list of supported crops ("crops" call)'),
     '#title_display' => 'before',
     '#required' => FALSE,
     '#size' => 80,
@@ -843,7 +869,10 @@ function brapi_admin_form_submit($form_id, &$form_state) {
   if ($form_state['values']['germplasm_pui']) {
     $storage_options['germplasm_pui'] = $form_state['values']['germplasm_pui'];
   }
-  // Crop list storage.
+  // Crop list storage method and override list.
+  if ($form_state['values']['crop_naming_method']) {
+    $storage_options['crop_naming_method'] = $form_state['values']['crop_naming_method'];
+  }
   if ($form_state['values']['crop_list']) {
     $storage_options['crop_list'] = $form_state['values']['crop_list'];
   }


### PR DESCRIPTION
Changes are described more fully in issue #38.
This creates three alternative methods to the current "species" method of generating names of crops.