### PR TITLE
7.x Issue #42 Chado 1.3 infraspecific nomenclature

### DIFF
--- a/api/brapi.api.inc
+++ b/api/brapi.api.inc
@@ -3486,7 +3486,7 @@ function brapi_get_subtaxon_info($organism_id) {
       SELECT
         o.species AS "species",
         sop.value AS "speciesAuthority",
-        REPLACE(CONCAT_WS(\' \', cv.name, o.infraspecific_name), \' no_rank\', \'\') AS "subtaxa",
+        CONCAT_WS(\' \', REPLACE(cv.name, \'no_rank\', \'\'), o.infraspecific_name) AS "subtaxa",
         ssop.value AS "subtaxaAuthority"
       FROM {organism} o
       LEFT JOIN {cvterm} cv ON (

--- a/api/brapi.api.inc
+++ b/api/brapi.api.inc
@@ -3463,6 +3463,68 @@ function brapi_get_organism_info($organism_id) {
 }
 
 /**
+ * Returns information about an organism.
+ * This version uses the chado 1.3 type_id and infraspecific_name columns
+ * in the organism table to generate the subtaxa name.
+ *
+ * @param int $organism_id
+ *   Value of organism.organism_id of the organism of interest.
+ *
+ * @return array
+ *   An array with the following keys:
+ *   - "species": name of the species/group or NULL;
+ *   - "speciesAuthority": species authority or NULL;
+ *   - "subtaxa": name of the subspecies or subgroup or NULL;
+ *   - "subtaxaAuthority": subtaxa authority or NULL.
+ */
+function brapi_get_subtaxon_info($organism_id) {
+  static $organism_data = array();
+  $cv_settings = brapi_get_cv_settings();
+
+  if (!array_key_exists($organism_id, $organism_data)) {
+    $sql_query = '
+      SELECT
+        o.species AS "species",
+        sop.value AS "speciesAuthority",
+        REPLACE(CONCAT_WS(\' \', cv.name, o.infraspecific_name), \' no_rank\', \'\') AS "subtaxa",
+        ssop.value AS "subtaxaAuthority"
+      FROM {organism} o
+      LEFT JOIN {cvterm} cv ON (
+        o.type_id = cv.cvterm_id
+      )
+      LEFT JOIN {organismprop} sop ON (
+        o.organism_id = sop.organism_id
+        AND sop.type_id IN (:species_authority)
+      )
+      LEFT JOIN {organismprop} ssop ON (
+        o.organism_id = ssop.organism_id
+        AND ssop.type_id IN (:subtaxa_authority)
+      )
+      WHERE
+        o.organism_id = :organism_id
+      ;';
+    $filter_values = array(
+      ':organism_id' => $organism_id,
+      ':species_authority' => $cv_settings['speciesAuthority'],
+      ':subtaxa_authority' => $cv_settings['subtaxaAuthority'],
+    );
+    $species_result = chado_query($sql_query, $filter_values);
+    if ($species_result) {
+      $organism_data[$organism_id] = $species_result->fetchAssoc();
+    }
+    else {
+      $organism_data[$organism_id] = array(
+        'species' => NULL,
+        'speciesAuthority' => NULL,
+        'subtaxa' => NULL,
+        'subtaxaAuthority' => NULL,
+      );
+    }
+  }
+  return $organism_data[$organism_id];
+}
+
+/**
  * Helper function that returns CV/CV term filter for CV terms.
  *
  * @param array $cvterm_settings

--- a/api/brapi.const.inc
+++ b/api/brapi.const.inc
@@ -2450,6 +2450,22 @@ function brapi_get_data_mapping() {
       }
       return $data;
     };
+    $subtaxon_info_func = function ($data_type, $stock, $field_name, $op, $values = NULL) {
+      $data = '';
+      switch ($op) {
+        case NULL:
+          $data = array('read' => TRUE);
+          break;
+
+        case 'read':
+          $organism_info = brapi_get_subtaxon_info($stock->organism_id->organism_id);
+          $data = $organism_info[$field_name];
+          break;
+
+        default:
+      }
+      return $data;
+    };
 
     $brapi_data_mapping = array(
       'germplasm'      => array(
@@ -2741,6 +2757,15 @@ function brapi_get_data_mapping() {
             'selector' => [],
             'field_type' => 'string',
           ],
+          'speciesInfra' => [
+            // Species and subspecies from chado.organism.
+            'table' => 'organism',
+            'foreign_key' => 'organism_id',
+            'object_key' => 'organism_id',
+            'column' => 'species',
+            'selector' => [],
+            'field_type' => 'string',
+          ],
           'speciesProp' => [
             // Species from MCPD.
             'table' => 'stockprop',
@@ -2974,6 +2999,10 @@ function brapi_get_data_mapping() {
           'speciesAuthorityFunc' => $organism_info_func,
           'subtaxaFunc' => $organism_info_func,
           'subtaxaAuthorityFunc' => $organism_info_func,
+          'speciesInfraFunc' => $subtaxon_info_func,
+          'speciesInfraAuthorityFunc' => $subtaxon_info_func,
+          'subtaxaInfraFunc' => $subtaxon_info_func,
+          'subtaxaInfraAuthorityFunc' => $subtaxon_info_func,
           'taxonId' => function ($data_type, $stock, $field_name, $op, $values = NULL) {
             $taxon_id = NULL;
             switch ($op) {
@@ -3901,6 +3930,13 @@ function brapi_get_data_mapping() {
           $germplasm_fields['speciesAuthority']['alias_for'] = 'speciesAuthorityProp';
           $germplasm_fields['subtaxa']['alias_for'] = 'subtaxaProp';
           $germplasm_fields['subtaxaAuthority']['alias_for'] = 'subtaxaAuthorityProp';
+          break;
+
+        case 'speciesInfraFunc':
+          $germplasm_fields['species']['alias_for'] = 'speciesInfraFunc';
+          $germplasm_fields['speciesAuthority']['alias_for'] = 'speciesInfraAuthorityFunc';
+          $germplasm_fields['subtaxa']['alias_for'] = 'subtaxaInfraFunc';
+          $germplasm_fields['subtaxaAuthority']['alias_for'] = 'subtaxaInfraAuthorityFunc';
           break;
 
         default:

--- a/includes/brapi.admin.inc
+++ b/includes/brapi.admin.inc
@@ -182,7 +182,8 @@ function brapi_admin_form($form, &$form_state, $no_js_use = FALSE) {
   // Species storage.
   $species_options = array(
     'speciesProp' => t('Stored in stockprop table'),
-    'speciesOrganism' => t('Stored in organism table'),
+    'speciesOrganism' => t('Stored species in organism table, subtaxa in stockprop table'),
+    'speciesInfraFunc' => t('Stored both species and subtaxa in organism table'),
     'speciesFunc' => t('Stored in organism + phylonode tables'),
   );
   $species_storage = isset($storage_options['species']) ?
@@ -190,7 +191,9 @@ function brapi_admin_form($form, &$form_state, $no_js_use = FALSE) {
     : '';
   if (!$species_storage
       || (($species_storage != 'speciesProp')
-          && ($species_storage != 'speciesOrganism'))) {
+          && ($species_storage != 'speciesOrganism')
+          && ($species_storage != 'speciesInfraFunc')
+          && ($species_storage != 'speciesFunc'))) {
     $species_storage = 'speciesOrganism';
   }
   $form['storage_options']['species_storage'] = array(


### PR DESCRIPTION
Proposed changes for issue #42
This adds another option for the "Species storage" setting that will use the chado 1.3 infraspecific nomenclature in the chado.organism table. "Stored species in organism table" has been renamed to reflect that subtaxon is actually from stockprop table.

![20220516_subtaxon](https://user-images.githubusercontent.com/8419404/168673703-f78f34e0-d216-4ae5-9dfa-810fb3b8510c.png)

I hope this was a reasonable approach to take.