### PR TITLE
7.x Issue #44 missing braces around chado table names

### DIFF
--- a/api/brapi.api.inc
+++ b/api/brapi.api.inc
@@ -3582,8 +3582,8 @@ function brapi_v1_get_cvterm_selector($cvterm_settings) {
     if (!empty($parent_cvterm_ids)) {
       $sql_query = "
         SELECT DISTINCT subject_id
-        FROM cvterm_relationship
-          JOIN cvterm ON (cvterm_id = type_id AND name IN ('is_a', 'isa'))
+        FROM {cvterm_relationship}
+          JOIN {cvterm} ON (cvterm_id = type_id AND name IN ('is_a', 'isa'))
         WHERE
           object_id IN (:values)
       ;";

--- a/api/brapi.const.inc
+++ b/api/brapi.const.inc
@@ -3670,7 +3670,7 @@ function brapi_get_data_mapping() {
                 $sql_query = '
                   SELECT c.name
                   FROM {contact} c
-                    JOIN {project_contact pc USING (contact_id)
+                    JOIN {project_contact} pc USING (contact_id)
                   WHERE
                     pc.project_id = :project_id
                     AND c.type_id = :lead_person_type_id

--- a/api/brapi.const.inc
+++ b/api/brapi.const.inc
@@ -3468,9 +3468,9 @@ function brapi_get_data_mapping() {
               case 'read':
                 $sql_query = '
                   SELECT db.name || \':\' || dbx.accession AS "trait_id"
-                  FROM cvterm cvt
-                    JOIN dbxref dbx USING (dbxref_id)
-                    JOIN db USING (db_id)
+                  FROM {cvterm} cvt
+                    JOIN {dbxref} dbx USING (dbxref_id)
+                    JOIN {db} USING (db_id)
                   WHERE cvterm_id = :cvterm_id
                 ;';
                 $filter_values = array(

--- a/brapi.install
+++ b/brapi.install
@@ -352,7 +352,7 @@ function brapi_cleanup_cvterms($remove = FALSE) {
     $t = get_t();
     drupal_set_message(
       $t(
-        'Obsolete BrAPI CV terms were not removed. To remove them manually, use the following SQL command: "DELETE FROM cvterm WHERE cvterm_id IN (%cvterm_ids);"',
+        'Obsolete BrAPI CV terms were not removed. To remove them manually, use the following SQL command: "DELETE FROM chado.cvterm WHERE cvterm_id IN (%cvterm_ids);"',
         array('%cvterm_ids' => implode(',', $cvterm_to_remove))
       ),
       'warning'


### PR DESCRIPTION
Simple fix for issue #44 to add braces around table names in sql destined for ```chado_query()``` calls, or add ```chado.``` prefix in the text presented by the installer.