### PR TITLE
Remove leadPerson from /brapi/v1/variables

### DIFF
--- a/api/brapi.calls.inc
+++ b/api/brapi.calls.inc
@@ -3170,7 +3170,6 @@ function brapi_get_variables_details_11($cvterm) {
     'name',
     'abbreviation',
     'objective',
-    'leadPerson',
   );
 
   // Handle 'include'.

--- a/api/brapi.const.inc
+++ b/api/brapi.const.inc
@@ -3685,43 +3685,6 @@ function brapi_get_data_mapping() {
           'observationVariableDbId' => array(
             'alias_for' => 'variableDbId',
           ),
-
-          // Table joins.
-          // Function fields.
-          'leadPerson' => function ($data_type, $cvterm, $field_name, $op, $values = NULL) use ($cv_settings) {
-            $lead_contact = NULL;
-            switch ($op) {
-              case NULL:
-                $lead_contact = array('read' => TRUE);
-                break;
-
-              case 'read':
-                $sql_query = '
-                  SELECT c.name
-                  FROM {contact} c
-                    JOIN {project_contact} pc USING (contact_id)
-                  WHERE
-                    pc.project_id = :project_id
-                    AND c.type_id = :lead_person_type_id
-                ;';
-                $filter_values = array(
-                  ':project_id' => $project->project_id,
-                  ':lead_person_type_id' => $cv_settings['LeadPerson'],
-                );
-                $contact_result = chado_query($sql_query, $filter_values);
-                if ($contact_result) {
-                  $contact = $contact_result->fetchAssoc();
-                  $lead_contact = $contact['name'];
-                }
-                else {
-                  $lead_contact = NULL;
-                }
-                break;
-
-              default:
-            }
-            return $lead_contact;
-          },
         ),
       ),
       'map'          => array(


### PR DESCRIPTION
This eliminates the PHP8 warning described in issue #47 by eliminating leadPerson from ```/brapi/v1/variables``` which should not have been there in the first place as far as I can tell.
Other things in the brapi spec that are required are missing, but I won't tackle that here.